### PR TITLE
Integrate Spotbugs tool into Teedy system

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,20 @@
         </executions>
       </plugin>
 
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>4.7.2.1</version>
+        <dependencies>
+        <!-- overwrite dependency on spotbugs if want to specify spotbugs version-->
+          <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs</artifactId>
+            <version>4.7.3</version>
+          </dependency>
+        </dependencies>
+<     /plugin>
+
     </plugins>
   </build>
         

--- a/pom.xml
+++ b/pom.xml
@@ -549,13 +549,6 @@
         <version>${com.levigo.jbig2.levigo-jbig2-imageio.version}</version>
       </dependency>
 
-      <!-- SpotBugs -->
-      <dependency>
-        <groupId>com.github.spotbugs</groupId>
-        <artifactId>spotbugs</artifactId>
-        <version>4.7.3</version>
-      </dependency>
-
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,13 @@
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>4.7.2.1</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs</artifactId>
+            <version>4.7.3</version>
+          </dependency>
+        </dependencies>
       </plugin>
 
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -144,15 +144,7 @@
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>4.7.2.1</version>
-        <dependencies>
-        <!-- overwrite dependency on spotbugs if want to specify spotbugs version-->
-          <dependency>
-            <groupId>com.github.spotbugs</groupId>
-            <artifactId>spotbugs</artifactId>
-            <version>4.7.3</version>
-          </dependency>
-        </dependencies>
-<     /plugin>
+      </plugin>
 
     </plugins>
   </build>
@@ -539,7 +531,24 @@
         <version>${com.levigo.jbig2.levigo-jbig2-imageio.version}</version>
       </dependency>
 
+      <!-- SpotBugs -->
+      <dependency>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs</artifactId>
+        <version>4.7.3</version>
+      </dependency>
+
     </dependencies>
   </dependencyManagement>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>4.7.3.0</version>
+      </plugin>
+    </plugins>
+  </reporting>
   
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,17 @@
         </executions>
       </plugin>
 
+            <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>3.7.1</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>3.0.0</version>
+      </plugin>
+
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
@@ -152,7 +163,7 @@
           </dependency>
         </dependencies>
       </plugin>
-
+      
     </plugins>
   </build>
         


### PR DESCRIPTION
Integrated Spotbugs through maven plugin. Spotbugs reports should now be accessible by running "mvn site" and opening the spotbugs.html report generated under target/site. 